### PR TITLE
feat: add live templates and analog context

### DIFF
--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -51,6 +51,10 @@
     <directoryProjectGenerator implementation="org.analogjs.AnalogProjectGenerator"/>
     <!-- works in IDEA -->
     <projectTemplatesFactory implementation="org.analogjs.AnalogProjectTemplateFactory"/>
+    <defaultLiveTemplates file="/liveTemplates/Analog.xml"/>
+    <liveTemplateContext
+            contextId="ANALOG"
+            implementation="org.analogjs.liveTemplate.AnalogTemplateContextType"/>
   </extensions>
 
   <extensions defaultExtensionNs="JavaScript">

--- a/resources/liveTemplates/Analog.xml
+++ b/resources/liveTemplates/Analog.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templateSet group="Analog">
+    <template name="analog-component" value="&lt;script lang=&quot;ts&quot;&gt;&#10;&#10;&lt;/script&gt;&#10;&#10;&lt;template&gt;&#10;&#10;&lt;/template&gt;&#10;&#10;&lt;style&gt;&#10;&#10;&lt;/style&gt;" description="Create an empty Analog SFC" toReformat="false" toShortenFQNames="true">
+        <context>
+            <option name="ANALOG" value="true" />
+        </context>
+    </template>
+</templateSet>

--- a/resources/messages/AnalogBundle.properties
+++ b/resources/messages/AnalogBundle.properties
@@ -9,3 +9,4 @@ analog.create.directive.template.component=Component
 analog.create.directive.template.directive=Directive
 analog.project.create.name=Analog
 analog.project.create.description=Create an Analog project
+analog.live.template.context=Analog

--- a/src/org/analogjs/liveTemplate/AnalogTemplateContextType.kt
+++ b/src/org/analogjs/liveTemplate/AnalogTemplateContextType.kt
@@ -1,0 +1,10 @@
+package org.analogjs.liveTemplate
+
+import com.intellij.codeInsight.template.TemplateActionContext
+import com.intellij.codeInsight.template.TemplateContextType
+import org.analogjs.AnalogBundle
+import org.analogjs.lang.AnalogFile
+
+class AnalogTemplateContextType : TemplateContextType(AnalogBundle.message("analog.live.template.context")) {
+    override fun isInContext(context: TemplateActionContext) = context.file is AnalogFile
+}


### PR DESCRIPTION
Live Templates are somewhat comparable to vscode snippets. The one added here is just a basic empty component, but it also adds the analog context so that you can easily add new snippets in the settings